### PR TITLE
feat: bump base image to match upnp, diag, config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 ####################################################################################################
 ########################### Stage: PktFwd Python App Builder #######################################
-FROM balenalib/raspberry-pi-debian-python:buster-build-20210705 as pktfwd-builder
+FROM balenalib/raspberry-pi-debian-python:buster-build-20211014 as pktfwd-builder
 
 # Variables used internally to this stage
 ENV INPUT_DIR=/opt/input
@@ -21,7 +21,7 @@ RUN pip3 install --target="$OUTPUT_DIR" --no-cache-dir -r requirements.txt
 
 ###################################################################################################
 ################################## Stage: runner ##################################################
-FROM balenalib/raspberry-pi-debian-python:buster-run-20210705 as pktfwd-runner
+FROM balenalib/raspberry-pi-debian-python:buster-run-20211014 as pktfwd-runner
 
 ENV ROOT_DIR=/opt
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

to have smaller os image by using same base image accross containers

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump to more up to date base image

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/helium-miner-software/issues/182