### PR TITLE
fix: correctly check returncode of sx1302 check

### DIFF
--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -69,15 +69,13 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
                        text=True, check=True).stdout
-
+        return True
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
-    except CalledProcessError:
+    except subprocess.CalledProcessError:
         return False
     except Exception:
-        pass
-    else:
-        return True
+        pass   
 
 
 def get_region_filename(region):

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -68,7 +68,7 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
 
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
-                       text=True, check=True)
+                       text=True, check=True).stdout
         return True
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
@@ -83,13 +83,13 @@ def get_region_filename(region):
     return REGION_CONFIG_FILENAMES[region]
 
 
-def update_global_conf(is_sx1302, root_dir, sx1301_region_configs_dir,
+def update_global_conf(is_concentrator_sx1302, root_dir, sx1301_region_configs_dir,
                        sx1302_region_configs_dir, region, spi_bus):
     """
     Replace global_conf.json with the configuration necessary given
     the concentrator chip type, region, and spi_bus.
     """
-    if is_sx1302:
+    if is_concentrator_sx1302:
         replace_sx1302_global_conf_with_regional(sx1302_region_configs_dir,
                                                  region, spi_bus)
     else:
@@ -141,7 +141,7 @@ def replace_sx1302_global_conf_with_regional(sx1302_region_configs_dir,
 
 @retry(wait=wait_fixed(LORA_PKT_FWD_AFTER_FAILURE_SLEEP_SECONDS),
        before_sleep=before_sleep_log(LOGGER, LOGLEVEL_INT))
-def retry_start_concentrator(is_sx1302, spi_bus,
+def retry_start_concentrator(is_concentrator_sx1302, spi_bus,
                              sx1302_lora_pkt_fwd_filepath,
                              sx1301_lora_pkt_fwd_dir,
                              reset_lgw_filepath,
@@ -151,7 +151,7 @@ def retry_start_concentrator(is_sx1302, spi_bus,
     """
     lora_pkt_fwd_filepath = sx1302_lora_pkt_fwd_filepath
 
-    if not is_sx1302:
+    if not is_concentrator_sx1302:
         # sx1301 must explicitly reset,
         # sx1302 automatically resets before starting
         run_reset_lgw(reset_lgw_filepath)

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -68,7 +68,7 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
 
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
-                       text=True, check=True).stdout
+                       text=True, check=True)
         return True
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -75,7 +75,7 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
     except subprocess.CalledProcessError:
         return False
     except Exception:
-        pass   
+        pass
 
 
 def get_region_filename(region):
@@ -92,9 +92,11 @@ def update_global_conf(is_sx1302, root_dir, sx1301_region_configs_dir,
     the concentrator chip type, region, and spi_bus.
     """
     if is_sx1302:
+        LOGGER.debug("SX1302 / SX1303 Detected")
         replace_sx1302_global_conf_with_regional(sx1302_region_configs_dir,
                                                  region, spi_bus)
     else:
+        LOGGER.debug("No chip EUI. Assume SX1301")
         replace_sx1301_global_conf_with_regional(root_dir,
                                                  sx1301_region_configs_dir,
                                                  region)

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -69,11 +69,15 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
                        text=True, check=True).stdout
-        return True
+
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
-    except Exception:
+    except CalledProcessError:
         return False
+    except Exception:
+        pass
+    else:
+        return True
 
 
 def get_region_filename(region):
@@ -83,13 +87,13 @@ def get_region_filename(region):
     return REGION_CONFIG_FILENAMES[region]
 
 
-def update_global_conf(is_concentrator_sx1302, root_dir, sx1301_region_configs_dir,
+def update_global_conf(is_sx1302, root_dir, sx1301_region_configs_dir,
                        sx1302_region_configs_dir, region, spi_bus):
     """
     Replace global_conf.json with the configuration necessary given
     the concentrator chip type, region, and spi_bus.
     """
-    if is_concentrator_sx1302:
+    if is_sx1302:
         replace_sx1302_global_conf_with_regional(sx1302_region_configs_dir,
                                                  region, spi_bus)
     else:
@@ -141,7 +145,7 @@ def replace_sx1302_global_conf_with_regional(sx1302_region_configs_dir,
 
 @retry(wait=wait_fixed(LORA_PKT_FWD_AFTER_FAILURE_SLEEP_SECONDS),
        before_sleep=before_sleep_log(LOGGER, LOGLEVEL_INT))
-def retry_start_concentrator(is_concentrator_sx1302, spi_bus,
+def retry_start_concentrator(is_sx1302, spi_bus,
                              sx1302_lora_pkt_fwd_filepath,
                              sx1301_lora_pkt_fwd_dir,
                              reset_lgw_filepath,
@@ -151,7 +155,7 @@ def retry_start_concentrator(is_concentrator_sx1302, spi_bus,
     """
     lora_pkt_fwd_filepath = sx1302_lora_pkt_fwd_filepath
 
-    if not is_concentrator_sx1302:
+    if not is_sx1302:
         # sx1301 must explicitly reset,
         # sx1302 automatically resets before starting
         run_reset_lgw(reset_lgw_filepath)


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

sx1302 check not working correctly

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

due to the stdout passed to the function, it was not working correctly. this removes that so the returncode of the sx1302 check function is checked correctly and sx1302 or sx1303 based devices are correctly identified.

**References**
<!-- Links to related issues, relevant documentation, etc. -->
Closes: #70