### PR TITLE
fix: copy reset_lgw to expected path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV SX1302_REGION_CONFIGS_DIR="$PYTHON_APP_DIR/config/lora_templates_sx1302"
 ENV SX1302_LORA_PKT_FWD_FILEPATH="$SX1302_DIR/lora_pkt_fwd"
 ENV UTIL_CHIP_ID_FILEPATH="$SX1302_DIR/chip_id"
 # The sx1302_hal concentrator script requires reset_lgw to be in this location
-ENV RESET_LGW_FILEPATH="$SX1302_DIR/reset_lgw.sh"
+ENV RESET_LGW_FILEPATH="$ROOT_DIR/reset_lgw.sh"
 
 WORKDIR "$ROOT_DIR"
 

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -68,11 +68,13 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
 
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
-                       text=True, check=True).stdout
+                       text=True, check=True)
+        LOGGER.debug("SX1302 / SX1303 detected. util_chip_id script exited without error.")
         return True
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
     except Exception:
+        LOGGER.exception("SX1301 detected. util_chip_id script exited with error.")
         return False
 
 


### PR DESCRIPTION
**Why**
reset_lgw.sh should be in the directory that the Python app is invoked from. This is where sx1302 scripts are looking. They were previously failing when it was not in that location.

**How**
Copy to ROOT_DIR.

**References**

- Related to: https://github.com/NebraLtd/hm-pktfwd/issues/70