### PR TITLE
Silence hardware issues from Sentry

### DIFF
--- a/pktfwd/pktfwd_app.py
+++ b/pktfwd/pktfwd_app.py
@@ -56,7 +56,7 @@ class PktfwdApp:
         # retry_start_concentrator will hang indefinitely while the
         # upstream packet_forwarder runs. The lines below will only
         # be reached if the concentrator exits unexpectedly.
-        LOGGER.error("Unable to start concentrator. Shutting down.")
+        LOGGER.warning("Shutting down concentrator.")
         self.stop()
 
     def prepare_to_start(self):

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -73,14 +73,16 @@ def is_concentrator_sx1302(util_chip_id_filepath, spi_bus):
     try:
         subprocess.run(util_chip_id_cmd, capture_output=True,
                        text=True, check=True)
-        LOGGER.debug("SX1302 / SX1303 detected. util_chip_id script exited without error.")
+        LOGGER.debug("SX1302 / SX1303 detected. \
+                     util_chip_id script exited without error.")
         return True
     # CalledProcessError raised if there is a non-zero exit code
     # https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module
     except subprocess.CalledProcessError as e:
         LOGGER.debug(e)
     except Exception:
-        LOGGER.exception("SX1301 detected. util_chip_id script exited with error.")
+        LOGGER.exception("SX1301 detected.\
+                          util_chip_id script exited with error.")
 
     return False
 
@@ -215,10 +217,11 @@ def retry_start_concentrator(is_sx1302, spi_bus,
         # by throwing an exception, which will trigger retry.
         elif lora_pkt_fwd_proc_returncode == 0:
             raise LoraPacketForwarderStoppedWithoutError(
-                "lora_pkt_fwd stopped without error.")
+                                                         "lora_pkt_fwd stopped\
+                                                           without error.")
 
         # lora_pkt_fwd exited with error. Restart the container by letting
         # the python application exit without error.
         else:
             LOGGER.warning("lora_pkt_fwd stopped with code=%s." %
-                         lora_pkt_fwd_proc_returncode)
+                           lora_pkt_fwd_proc_returncode)

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -220,5 +220,5 @@ def retry_start_concentrator(is_sx1302, spi_bus,
         # lora_pkt_fwd exited with error. Restart the container by letting
         # the python application exit without error.
         else:
-            LOGGER.error("lora_pkt_fwd stopped with code=%s." %
+            LOGGER.warning("lora_pkt_fwd stopped with code=%s." %
                          lora_pkt_fwd_proc_returncode)


### PR DESCRIPTION
**Issue**

- Link: #80 #81 
- Summary: Error occurs twice each time an issue is encountered

**How**
Changed #81 and #80 to log as warnings to silence them from displaying on Sentry. After discussing this further we have come to the conclusion that these issues are more than likely just hardware issues which shouldn't be recorded in Sentry.

**Checklist**

- [x] Cleaned up commit history (rebase!)
- [x] Thought about variable and method names