### PR TITLE
Add balena UUID and balena fleet name to sentry tag

### DIFF
--- a/pktfwd/__main__.py
+++ b/pktfwd/__main__.py
@@ -40,7 +40,7 @@ DIAGNOSTICS_FILEPATH = os.getenv('DIAGNOSTICS_FILEPATH', '/var/pktfwd/diagnostic
 AWAIT_SYSTEM_SLEEP_SECONDS = int(os.getenv('AWAIT_SYSTEM_SLEEP_SECONDS', '5'))
 
 # If False, Sentry will not be enabled
-SENTRY_KEY = os.getenv('SENTRY_PKTFWD', False)
+SENTRY_DSN = os.getenv('SENTRY_PKTFWD', False)
 
 #
 # Optional
@@ -66,7 +66,7 @@ def validate_env():
         REGION_FILEPATH=%s\n\
         SX1301_REGION_CONFIGS_DIR=%s\n\
         SX1302_REGION_CONFIGS_DIR=%s\n\
-        SENTRY_KEY=%s\n\
+        SENTRY_DSN=%s\n\
         BALENA_ID=%s\n\
         BALENA_APP=%s\n\
         DIAGNOSTICS_FILEPATH=%s\n\
@@ -77,7 +77,7 @@ def validate_env():
         SX1302_LORA_PKT_FWD_FILEPATH=%s\n\
         SX1301_LORA_PKT_FWD_DIR=%s\n" %
             (VARIANT, REGION_OVERRIDE, REGION_FILEPATH,  # noqa E128
-             SX1301_REGION_CONFIGS_DIR, SX1302_REGION_CONFIGS_DIR, SENTRY_KEY,
+             SX1301_REGION_CONFIGS_DIR, SX1302_REGION_CONFIGS_DIR, SENTRY_DSN,
              BALENA_ID, BALENA_APP, DIAGNOSTICS_FILEPATH,
              AWAIT_SYSTEM_SLEEP_SECONDS, RESET_LGW_FILEPATH,
              UTIL_CHIP_ID_FILEPATH, ROOT_DIR,
@@ -87,7 +87,7 @@ def validate_env():
 def start():
     pktfwd_app = PktfwdApp(VARIANT, REGION_OVERRIDE, REGION_FILEPATH,
                            SX1301_REGION_CONFIGS_DIR,
-                           SX1302_REGION_CONFIGS_DIR, SENTRY_KEY,
+                           SX1302_REGION_CONFIGS_DIR, SENTRY_DSN,
                            BALENA_ID, BALENA_APP,
                            DIAGNOSTICS_FILEPATH,
                            AWAIT_SYSTEM_SLEEP_SECONDS,

--- a/pktfwd/pktfwd_app.py
+++ b/pktfwd/pktfwd_app.py
@@ -15,13 +15,13 @@ RESET_LGW_RESET_PIN_ENV_KEY = "CONCENTRATOR_RESET_PIN"
 class PktfwdApp:
     def __init__(self, variant, region_override, region_filepath,
                  sx1301_region_configs_dir, sx1302_region_configs_dir,
-                 sentry_key, balena_id, balena_app,
+                 sentry_dsn, balena_id, balena_app,
                  diagnostics_filepath, await_system_sleep_seconds,
                  reset_lgw_filepath,
                  util_chip_id_filepath, root_dir,
                  sx1302_lora_pkt_fwd_filepath, sx1301_lora_pkt_fwd_dir):  # noqa
 
-        init_sentry(sentry_key, balena_id, balena_app)
+        init_sentry(sentry_dsn, balena_id, balena_app)
         self.set_variant_attributes(variant)
         self.sx1301_region_configs_dir = sx1301_region_configs_dir
         self.sx1302_region_configs_dir = sx1302_region_configs_dir

--- a/pktfwd/utils.py
+++ b/pktfwd/utils.py
@@ -23,15 +23,19 @@ class LoraPacketForwarderStoppedWithoutError(Exception):
     pass
 
 
-def init_sentry(sentry_key, balena_id, balena_app):
+def init_sentry(sentry_dsn, balena_id, balena_app):
     """
-    Initialize sentry with balena_app as environment and
-    balenda_id as the user's id. If sentry_key is not set,
-    do nothing.
+    Initialize sentry with balena_id and balena_app as tag.
+    If sentry_dsn is not set, do nothing.
     """
-    if(sentry_key):
-        sentry_sdk.init(sentry_key, environment=balena_app)
-        sentry_sdk.set_user({"id": balena_id})
+
+    if not sentry_dsn:
+        return
+
+    sentry_sdk.init(sentry_dsn)
+
+    sentry_sdk.set_tag("balena_id", balena_id)
+    sentry_sdk.set_tag("balena_app", balena_app)
 
 
 def write_diagnostics(diagnostics_filepath, is_running):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sentry-sdk==1.1.0
+sentry-sdk==1.6.0
 tenacity==8.0.1
 hm-pyhelper==0.13.32


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/405
- Summary:
Add balena device UUID and balena app name(fleet name) to senty issues as a tag. 
Sentry tag is very convenient for filtering, tag-distribution maps, the frequency and the last time that Sentry has seen a tag.
The primary benefit of the Balena device UUID tag is that it enables further analysis of the Sentry problem on the Balena dashboard.

**How**
- Inside the balena container, get the balena UUID from environment variable `BALENA_DEVICE_UUID` and get balena app name from environment variable `BALENA_APP_NAME`.
- Set sentry tag with balena UUID and balena app name respectively.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

