### PR TITLE
Remove unsupported JSON comments in config files

### DIFF
--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_1A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_1A
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_1B
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_1B
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_2A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_2A
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_3A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_3A
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_4A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AS923_4A
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.AU915_SB2
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.AU915_SB2
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.CN470_A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.CN470_A
@@ -4,11 +4,11 @@
         "com_path": "/dev/spidev1.2",
         "lorawan_public": true,
         "clksrc": 0,
-        "antenna_gain": 0, /* antenna gain, in dBi */
+        "antenna_gain": 0,
         "full_duplex": false,
         "fine_timestamp": {
             "enable": false,
-            "mode": "all_sf" /* high_capacity or all_sf */
+            "mode": "all_sf"
         },
         "radio_0": {
             "enable": true,
@@ -108,15 +108,12 @@
     "gateway_conf": {
         "gps_i2c_path": "/dev/i2c-1",
         "gateway_ID": "AA555A0000000000",
-        /* change with default server address/ports */
         "server_address": "helium-miner",
         "serv_port_up": 1680,
         "serv_port_down": 1680,
-        /* adjust the following parameters for your network */
         "keepalive_interval": 10,
         "stat_interval": 30,
         "push_timeout_ms": 100,
-        /* forward only valid packets */
         "forward_crc_valid": true,
         "forward_crc_error": false,
         "forward_crc_disabled": false

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.EU433
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.EU433
@@ -1,0 +1,115 @@
+{
+    "SX130x_conf": {
+        "com_type": "SPI",
+        "com_path": "/dev/spidev1.2",
+        "lorawan_public": true,
+        "clksrc": 0,
+        "antenna_gain": 0,
+        "full_duplex": false,
+        "fine_timestamp": {
+            "enable": false,
+            "mode": "all_sf"
+        },
+        "radio_0": {
+            "enable": true,
+            "type": "SX1250",
+            "single_input_mode": true,
+            "freq": 434375000,
+            "rssi_offset": -207.0,
+            "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
+            "tx_enable": true,
+            "tx_freq_min": 433050000,
+            "tx_freq_max": 434900000,
+            "tx_gain_lut":[
+                {"rf_power": -6, "pa_gain": 0, "pwr_idx":  0},
+                {"rf_power": -3, "pa_gain": 0, "pwr_idx":  1},
+                {"rf_power":  0, "pa_gain": 0, "pwr_idx":  2},
+                {"rf_power":  3, "pa_gain": 1, "pwr_idx":  3},
+                {"rf_power":  6, "pa_gain": 1, "pwr_idx":  4},
+                {"rf_power": 10, "pa_gain": 1, "pwr_idx":  5},
+                {"rf_power": 11, "pa_gain": 1, "pwr_idx":  6},
+                {"rf_power": 12, "pa_gain": 1, "pwr_idx":  7},
+                {"rf_power": 13, "pa_gain": 1, "pwr_idx":  8},
+                {"rf_power": 14, "pa_gain": 1, "pwr_idx":  9},
+                {"rf_power": 16, "pa_gain": 1, "pwr_idx": 10},
+                {"rf_power": 20, "pa_gain": 1, "pwr_idx": 11},
+                {"rf_power": 23, "pa_gain": 1, "pwr_idx": 12},
+                {"rf_power": 25, "pa_gain": 1, "pwr_idx": 13},
+                {"rf_power": 26, "pa_gain": 1, "pwr_idx": 14},
+                {"rf_power": 27, "pa_gain": 1, "pwr_idx": 15}
+            ]
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1250",
+            "freq": 433575000,
+            "rssi_offset": -207,
+            "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
+            "tx_enable": false
+        },
+        "chan_multiSF_All": {"spreading_factor_enable": [ 5, 6, 7, 8, 9, 10, 11, 12 ]},
+        "chan_multiSF_0": {
+            "enable": true,
+            "radio": 0,
+            "if": -1200000
+        },
+        "chan_multiSF_1": {
+            "enable": true,
+            "radio": 0,
+            "if": -1000000
+        },
+        "chan_multiSF_2": {
+            "enable": true,
+            "radio": 1,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            "enable": false
+        },
+        "chan_multiSF_4": {
+            "enable": false
+        },
+        "chan_multiSF_5": {
+            "enable": false
+        },
+        "chan_multiSF_6": {
+            "enable": false
+        },
+        "chan_multiSF_7": {
+            "enable": false
+        },
+        "chan_Lora_std": {
+            "enable": false
+        },
+        "chan_FSK": {
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        }
+    },
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        
+        "server_address": "helium-miner",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    },
+
+    "debug_conf": {
+        "ref_payload":[
+            {"id": "0xCAFE1234"},
+            {"id": "0xCAFE2345"}
+        ],
+        "log_file": "loragw_hal.log"
+    }
+}

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.EU868_A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.EU868_A
@@ -4,11 +4,11 @@
         "com_path": "/dev/spidev1.2",
         "lorawan_public": true,
         "clksrc": 0,
-        "antenna_gain": 0, /* antenna gain, in dBi */
+        "antenna_gain": 0,
         "full_duplex": false,
         "fine_timestamp": {
             "enable": false,
-            "mode": "all_sf" /* high_capacity or all_sf */
+            "mode": "all_sf"
         },
         "radio_0": {
             "enable": true,
@@ -94,7 +94,6 @@
             "spread_factor": 7
         },
         "chan_FSK": {
-            /* disabled */
             "enable": false,
             "radio": 0,
             "if": 300000,
@@ -105,15 +104,12 @@
     "gateway_conf": {
         "gps_i2c_path": "/dev/i2c-1",
         "gateway_ID": "AA555A0000000000",
-        /* change with default server address/ports */
         "server_address": "helium-miner",
         "serv_port_up": 1680,
         "serv_port_down": 1680,
-        /* adjust the following parameters for your network */
         "keepalive_interval": 10,
         "stat_interval": 30,
         "push_timeout_ms": 100,
-        /* forward only valid packets */
         "forward_crc_valid": true,
         "forward_crc_error": false,
         "forward_crc_disabled": false

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.IN865_A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.IN865_A
@@ -4,11 +4,11 @@
         "com_path": "/dev/spidev1.2",
         "lorawan_public": true,
         "clksrc": 0,
-        "antenna_gain": 0, /* antenna gain, in dBi */
+        "antenna_gain": 0,
         "full_duplex": false,
         "fine_timestamp": {
             "enable": false,
-            "mode": "all_sf" /* high_capacity or all_sf */
+            "mode": "all_sf"
         },
         "radio_0": {
             "enable": true,
@@ -81,7 +81,6 @@
             "enable": false
         },
         "chan_FSK": {
-            /* disabled */
             "enable": false,
             "radio": 0,
             "if": 300000,
@@ -91,15 +90,12 @@
     },
     "gateway_conf": {
         "gateway_ID": "AA555A0000000000",
-        /* change with default server address/ports */
         "server_address": "helium-miner",
         "serv_port_up": 1680,
         "serv_port_down": 1680,
-        /* adjust the following parameters for your network */
         "keepalive_interval": 10,
         "stat_interval": 30,
         "push_timeout_ms": 100,
-        /* forward only valid packets */
         "forward_crc_valid": true,
         "forward_crc_error": false,
         "forward_crc_disabled": false

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.KR920_A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.KR920_A
@@ -8,7 +8,7 @@
     "full_duplex": false,
     "fine_timestamp": {
         "enable": false,
-        "mode": "all_sf" /* high_capacity or all_sf */
+        "mode": "all_sf"
     },
     "radio_0": {
       "enable": true,
@@ -97,15 +97,12 @@
   },
   "gateway_conf": {
       "gateway_ID": "AA555A0000000000",
-      /* change with default server address/ports */
       "server_address": "helium-miner",
       "serv_port_up": 1680,
       "serv_port_down": 1680,
-      /* adjust the following parameters for your network */
       "keepalive_interval": 10,
       "stat_interval": 30,
       "push_timeout_ms": 100,
-      /* forward only valid packets */
       "forward_crc_valid": true,
       "forward_crc_error": false,
       "forward_crc_disabled": false

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.RU864
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.RU864
@@ -1,0 +1,1 @@
+global_conf.json.RU864_A

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.RU864_A
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.RU864_A
@@ -4,11 +4,11 @@
         "com_path": "/dev/spidev1.2",
         "lorawan_public": true,
         "clksrc": 0,
-        "antenna_gain": 0, /* antenna gain, in dBi */
+        "antenna_gain": 0,
         "full_duplex": false,
         "fine_timestamp": {
             "enable": false,
-            "mode": "all_sf" /* high_capacity or all_sf */
+            "mode": "all_sf"
         },
         "radio_0": {
             "enable": true,
@@ -88,7 +88,6 @@
             "enable": false
         },
         "chan_FSK": {
-            /* disabled */
             "enable": false,
             "radio": 0,
             "if": 300000,
@@ -98,15 +97,12 @@
     },
     "gateway_conf": {
         "gateway_ID": "AA555A0000000000",
-        /* change with default server address/ports */
         "server_address": "helium-miner",
         "serv_port_up": 1680,
         "serv_port_down": 1680,
-        /* adjust the following parameters for your network */
         "keepalive_interval": 10,
         "stat_interval": 30,
         "push_timeout_ms": 100,
-        /* forward only valid packets */
         "forward_crc_valid": true,
         "forward_crc_error": false,
         "forward_crc_disabled": false

--- a/pktfwd/config/lora_templates_sx1302/global_conf.json.US915_SB2
+++ b/pktfwd/config/lora_templates_sx1302/global_conf.json.US915_SB2
@@ -4,11 +4,11 @@
         "com_path": "/dev/spidev1.2",
         "lorawan_public": true,
         "clksrc": 0,
-        "antenna_gain": 0, /* antenna gain, in dBi */
+        "antenna_gain": 0,
         "full_duplex": false,
         "fine_timestamp": {
             "enable": false,
-            "mode": "all_sf" /* high_capacity or all_sf */
+            "mode": "all_sf"
         },
         "radio_0": {
             "enable": true,
@@ -47,55 +47,46 @@
             "tx_enable": false
         },
         "chan_multiSF_0": {
-            /* Channel 8, 903.900 Mhz */
             "enable": true,
             "radio": 0,
             "if": -400000
         },
         "chan_multiSF_1": {
-            /* Channel 9, 904.100 Mhz */
             "enable": true,
             "radio": 0,
             "if": -200000
         },
         "chan_multiSF_2": {
-            /* Channel 10, 904.300 Mhz */
             "enable": true,
             "radio": 0,
             "if": 0
         },
         "chan_multiSF_3": {
-            /* Channel 11, 904.500 Mhz */
             "enable": true,
             "radio": 0,
             "if": 200000
         },
         "chan_multiSF_4": {
-            /* Channel 12, 904.700 Mhz */
             "enable": true,
             "radio": 1,
             "if": -300000
         },
         "chan_multiSF_5": {
-            /* Channel 13, 904.900 Mhz */
             "enable": true,
             "radio": 1,
             "if": -100000
         },
         "chan_multiSF_6": {
-            /* Channel 14, 905.100 Mhz */
             "enable": true,
             "radio": 1,
             "if": 100000
         },
         "chan_multiSF_7": {
-            /* Channel 15, 905.300 Mhz */
             "enable": true,
             "radio": 1,
             "if": 300000
         },
         "chan_Lora_std": {
-            /* Channel 65 (fat channel), 912.6 Mhz */
             "enable": true,
             "radio": 0,
             "if": 300000,
@@ -103,7 +94,6 @@
             "spread_factor": 8
         },
         "chan_FSK": {
-            /* disabled */
             "enable": false,
             "radio": 0,
             "if": 300000,
@@ -114,15 +104,12 @@
     "gateway_conf": {
         "gps_i2c_path": "/dev/i2c-1",
         "gateway_ID": "AA555A0000000000",
-        /* change with default server address/ports */
         "server_address": "helium-miner",
         "serv_port_up": 1680,
         "serv_port_down": 1680,
-        /* adjust the following parameters for your network */
         "keepalive_interval": 10,
         "stat_interval": 30,
         "push_timeout_ms": 100,
-        /* forward only valid packets */
         "forward_crc_valid": true,
         "forward_crc_error": false,
         "forward_crc_disabled": false


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pktfwd/issues/103
- Summary:
 Helium packet forwarder supports C style comments in config JSON files, but these comments are not supported by Python json library. `hm-pktfwd` uses Python to manipulate the config JSON files. 

**How**
- Remove JSON comments in packet forwarder config files.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names