### PR TITLE
feat: restart concentrator if regulatory region has changed#110

### DIFF
--- a/pktfwd/pktfwd_app.py
+++ b/pktfwd/pktfwd_app.py
@@ -51,7 +51,8 @@ class PktfwdApp:
                                  self.sx1302_lora_pkt_fwd_filepath,
                                  self.sx1301_lora_pkt_fwd_dir,
                                  self.reset_lgw_filepath,
-                                 self.diagnostics_filepath)
+                                 self.diagnostics_filepath,
+                                 self.region_filepath)
 
         # retry_start_concentrator will hang indefinitely while the
         # upstream packet_forwarder runs. The lines below will only


### PR DESCRIPTION
* we exit hm-pktfwd app and let balena reload container which will result in correct settings being loaded.

**[Issue](https://github.com/NebraLtd/hm-pktfwd/issues/110)**

- Link: https://github.com/NebraLtd/hm-pktfwd/issues/110
- Summary: exit miner nomally if region plan changes, balena will reload the  container with all new settings.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names